### PR TITLE
Memory-mapped BWLCD

### DIFF
--- a/lc3plugins/bwlcd.cpp
+++ b/lc3plugins/bwlcd.cpp
@@ -72,6 +72,7 @@ void destroy_plugin(Plugin* ptr = NULL)
     heightaddr(_heightaddr), initaddr(_initaddr), startaddr(_startaddr), offcolor(_offcolor), oncolor(_oncolor), maxsize(_maxsize), lcd(NULL),
     lcd_initializing(false)
 {
+    width = height = 0;
     Connect(wxID_ANY, wxEVT_COMMAND_CREATE_DISPLAY, wxThreadEventHandler(BWLCDPlugin::InitDisplay));
     Connect(wxID_ANY, wxEVT_COMMAND_DESTROY_DISPLAY, wxThreadEventHandler(BWLCDPlugin::DestroyDisplay));
 }
@@ -154,7 +155,7 @@ void BWLCDPlugin::OnMemoryWrite(lc3_state& state, unsigned short address, short 
             lc3_warning(state, "Incorrect value written to BWLCD");
         }
     }
-    else if (address >= startaddr && !lcd_initializing && address < startaddr + lcd->width * lcd->height)
+    else if (address >= startaddr && address < startaddr + width * height)
     {
         if (lcd == NULL)
         {

--- a/lc3plugins/bwlcd.hpp
+++ b/lc3plugins/bwlcd.hpp
@@ -10,6 +10,7 @@
 #define BWLCD_MINOR_VERSION 3
 
 #define TILE_SIZE 10
+#define MIN_SIZE 100
 
 wxDECLARE_EVENT(wxEVT_COMMAND_CREATE_DISPLAY, wxThreadEvent);
 wxDECLARE_EVENT(wxEVT_COMMAND_DESTROY_DISPLAY, wxThreadEvent);
@@ -18,7 +19,7 @@ wxDECLARE_EVENT(wxEVT_COMMAND_UPDATE_DISPLAY, wxThreadEvent);
 class BWLCD : public BWLCDGUI
 {
     public:
-        BWLCD(wxWindow* top, int width, int height, unsigned short startaddr, unsigned int off, unsigned int on);
+        BWLCD(wxWindow* top, int width, int height, unsigned short startaddr, unsigned int off, unsigned int on, unsigned int maxsize);
         ~BWLCD();
 		virtual void OnUpdate(wxThreadEvent& event);
 		void OnPaint( wxPaintEvent& event );
@@ -29,12 +30,13 @@ class BWLCD : public BWLCDGUI
         unsigned short startaddr;
         unsigned int off;
         unsigned int on;
+	unsigned int maxsize;
 };
 
 class BWLCDPlugin : public wxEvtHandler, public Plugin
 {
     public:
-        BWLCDPlugin(unsigned short widthaddr, unsigned short heightaddr, unsigned short initaddr, unsigned short startaddr, unsigned int offcolor = 0xa0b0a0, unsigned int oncolor = 0x606860);
+        BWLCDPlugin(unsigned short widthaddr, unsigned short heightaddr, unsigned short initaddr, unsigned short startaddr, unsigned int offcolor = 0xa0b0a0, unsigned int oncolor = 0x606860, unsigned int maxsize = 500);
         ~BWLCDPlugin();
         virtual void OnMemoryWrite(lc3_state& state, unsigned short address, short value);
         //virtual void OnTock(lc3_state& state);
@@ -50,6 +52,7 @@ class BWLCDPlugin : public wxEvtHandler, public Plugin
         unsigned short startaddr;
         unsigned int offcolor;
         unsigned int oncolor;
+	unsigned int maxsize;
         BWLCD* lcd;
         bool lcd_initializing;
 

--- a/lc3plugins/bwlcd.hpp
+++ b/lc3plugins/bwlcd.hpp
@@ -9,6 +9,8 @@
 #define BWLCD_MAJOR_VERSION 1
 #define BWLCD_MINOR_VERSION 3
 
+#define TILE_SIZE 10
+
 wxDECLARE_EVENT(wxEVT_COMMAND_CREATE_DISPLAY, wxThreadEvent);
 wxDECLARE_EVENT(wxEVT_COMMAND_DESTROY_DISPLAY, wxThreadEvent);
 wxDECLARE_EVENT(wxEVT_COMMAND_UPDATE_DISPLAY, wxThreadEvent);
@@ -20,10 +22,10 @@ class BWLCD : public BWLCDGUI
         ~BWLCD();
 		virtual void OnUpdate(wxThreadEvent& event);
 		void OnPaint( wxPaintEvent& event );
+	int width;
+	int height;
     private:
         lc3_state* state;
-        int width;
-        int height;
         unsigned short startaddr;
         unsigned int off;
         unsigned int on;
@@ -32,7 +34,7 @@ class BWLCD : public BWLCDGUI
 class BWLCDPlugin : public wxEvtHandler, public Plugin
 {
     public:
-        BWLCDPlugin(unsigned short width, unsigned short height, unsigned short initaddr, unsigned short startaddr, unsigned int offcolor = 0xa0b0a0, unsigned int oncolor = 0x606860);
+        BWLCDPlugin(unsigned short widthaddr, unsigned short heightaddr, unsigned short initaddr, unsigned short startaddr, unsigned int offcolor = 0xa0b0a0, unsigned int oncolor = 0x606860);
         ~BWLCDPlugin();
         virtual void OnMemoryWrite(lc3_state& state, unsigned short address, short value);
         //virtual void OnTock(lc3_state& state);
@@ -41,7 +43,9 @@ class BWLCDPlugin : public wxEvtHandler, public Plugin
         void DestroyDisplay(wxThreadEvent& event);
     private:
         unsigned short width;
-        unsigned short height;
+	unsigned short height;
+        unsigned short widthaddr;
+        unsigned short heightaddr;
         unsigned short initaddr;
         unsigned short startaddr;
         unsigned int offcolor;


### PR DESCRIPTION
BWLCD plugin memory-mapped. Made the process of drawing the LCD a little better at scaling. Added a maxsize param to the plugin. Put max and min screen size bound checks on creation of the BWLCD screen (so it isn't unreasonably small or large), and it is automatically resized accordingly.

Write the size parameters to the memory-mapped addresses before initializing the screen.
