### PR TITLE
Fix install script freezing on ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,9 @@ fi
 type apt-get >/dev/null 2>&1 || { echo >&2 "APT required, perhaps you don't have a Debian variant installed?"; exit 1; }
 
 echo "Installing package build-essential"
-apt-get install build-essential > /dev/null
+apt-get install -y build-essential > /dev/null
 echo "Installing wxWidgets 3.0"
-apt-get install libwxgtk3.0-dev > /dev/null
+apt-get install -y libwxgtk3.0-dev > /dev/null
 echo "Building program"
 make
 echo "Installing program"

--- a/install_script_ubuntu_13_10.sh
+++ b/install_script_ubuntu_13_10.sh
@@ -37,10 +37,10 @@ echo >&2 "Updating list of packages..."
 sudo apt-get update
  
 echo >&2 "Installing package build-essential..."
-gksu apt-get install build-essential
+gksu apt-get install -y build-essential
 
 echo >&2 "Installing wxwidgets 3.0..."
-sudo apt-get install libwxbase3.0-0-unofficial libwxbase3.0-dev libwxgtk3.0-0-unofficial libwxgtk3.0-dev wx3.0-headers wx-common
+sudo apt-get install -y libwxbase3.0-0-unofficial libwxbase3.0-dev libwxgtk3.0-0-unofficial libwxgtk3.0-dev wx3.0-headers wx-common
 
 echo >&2 "Building complx..."
 make


### PR DESCRIPTION
Currently, on a clean ubuntu/debian install, the install script freezes as the apt-get command is waiting for the user to confirm installation (but hides the output, so the user does not press anything). This solves that issue by adding the -y flag to the install commands.