### PR TITLE
Improve cross-platform build experience and usability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,48 @@
 cmake_minimum_required(VERSION 2.6)
+cmake_policy(SET CMP0042 NEW) # ignore warnings about rpath behavior on OS X
 project(complx-tools)
 
 option(ENABLE_PLUGINS "Enable Official Plugins" ON)
-option(ENABLE_DEBUG "Build debug version" OFF)
 option(ENABLE_LC3EDIT "Build lc3edit" OFF)
 option(ENABLE_COMP "Build comp" OFF)
 option(ENABLE_DEV "Build dev version" OFF)
 
-IF(ENABLE_PLUGINS)
+if(ENABLE_PLUGINS)
     add_subdirectory(plugins)
-ENDIF(ENABLE_PLUGINS)
+endif(ENABLE_PLUGINS)
 
 if(ENABLE_LC3EDIT)
     add_subdirectory(lc3edit)
-ENDIF(ENABLE_LC3EDIT)
+endif(ENABLE_LC3EDIT)
 
 if(ENABLE_COMP)
     add_subdirectory(comp)
-ENDIF(ENABLE_COMP)
+endif(ENABLE_COMP)
 
-IF(ENABLE_DEBUG)
-    set(CMAKE_CXX_FLAGS "-g -pg -Wall -std=c++11")
-ELSE()
-    set(CMAKE_CXX_FLAGS "-O3 -Wall -std=c++11")
-    set(CMAKE_EXE_LINKER_FLAGS "-s")
-ENDIF(ENABLE_DEBUG)
+# Require C++11 build
+if(NOT CMAKE_CXX_FLAGS MATCHES "-std=(c|gnu)\\+\\+11")
+    message(STATUS "This project requires C++11. Adding -std=c++11 to CXXFLAGS.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" CACHE STRING "Flags used by the compiler during all build types." FORCE)
+endif()
 
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# Enable all warning on debug builds
+set(CMAKE_CXX_FLAGS_DEBUG "-g -pg -Wall")
+
+# Default to release build if not specified
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif(NOT CMAKE_BUILD_TYPE)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     add_definitions(-DLINUX)
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     add_definitions(-DLINUX)
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 add_definitions(-DPREFIX=${CMAKE_INSTALL_PREFIX})
 add_definitions(-DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
@@ -177,5 +187,3 @@ install(FILES doc/PattPatelAppA.pdf DESTINATION share/doc/complx-tools)
 install(FILES doc/complx-tips.txt DESTINATION share/doc/complx-tools)
 install(FILES complx.png DESTINATION share/icons)
 install(FILES complx.desktop DESTINATION share/applications)
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ add_definitions(-DPREFIX=${CMAKE_INSTALL_PREFIX})
 add_definitions(-DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
 set(wxWidgets_USE_LIBS stc xrc xml html adv gl net core base)
 find_package(wxWidgets REQUIRED)
-execute_process(COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --cxxflags)
 set(CMAKE_SKIP_RPATH TRUE)
 include(${wxWidgets_USE_FILE})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 add_definitions(-DPREFIX=${CMAKE_INSTALL_PREFIX})
+add_definitions(-DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
 set(wxWidgets_USE_LIBS stc xrc xml html adv gl net core base)
 find_package(wxWidgets REQUIRED)
 execute_process(COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --cxxflags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,13 @@ if(NOT CMAKE_CXX_FLAGS MATCHES "-std=(c|gnu)\\+\\+11")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" CACHE STRING "Flags used by the compiler during all build types." FORCE)
 endif()
 
-# Enable all warning on debug builds
-set(CMAKE_CXX_FLAGS_DEBUG "-g -pg -Wall")
+# Additional debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "-g -pg")
+
+# Set default warning flags
+set(PROJECT_WARNING_FLAGS "-Wall" CACHE STRING "Compiler warning flags to include")
+mark_as_advanced(PROJECT_WARNING_FLAGS)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PROJECT_WARNING_FLAGS}")
 
 # Default to release build if not specified
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ include(${wxWidgets_USE_FILE})
 
 include_directories(${complx-tools_SOURCE_DIR}/liblc3)
 include_directories(${complx-tools_SOURCE_DIR}/lc3test)
-link_directories(${complx-tools_BINARY_DIR}/liblc3) 
 
 set(SRC_LIBLC3
     liblc3/ExpressionEvaluator.cpp

--- a/complx/ComplxFrame.cpp
+++ b/complx/ComplxFrame.cpp
@@ -1441,7 +1441,7 @@ void ComplxFrame::UpdatePlay(void)
     nextLineButton->SetLabel(_("&Next Line"));
     prevLineButton->SetLabel(_("&Prev Line"));
     finishButton->SetLabel(_("&Finish"));
-    rewindButton->SetLabel(_("Re&wind"));
+    rewindButton->SetLabel(_("Rewin&d"));
 }
 
 /** UpdatePhrase

--- a/complx/GridCellBinaryRenderer.cpp
+++ b/complx/GridCellBinaryRenderer.cpp
@@ -122,9 +122,9 @@ void GridCellBinaryRenderer::Draw(wxGrid &grid, wxGridCellAttr &attr, wxDC &dc, 
 void GridCellBinaryRenderer::InstructionColor(wxGrid &grid, wxGridCellAttr &attr, wxDC &dc, const wxRect &srect, int item, int column, bool isSelected)
 {
     wxRect rect = srect;
-    int width = 8/*dc.GetCharWidth()*/, height = rect.GetHeight();
+    int width = dc.GetCharWidth(), height = rect.GetHeight();
     int textwidth = dc.GetTextExtent(grid.GetCellValue(item, column)).GetWidth();
-    rect.Offset((srect.GetWidth() - textwidth) / 2 - 3, 0 );
+    rect.Offset(2, 0);
 
     dc.SetBrush(*wxBLACK);
     dc.DrawRectangle(srect.GetX(), srect.GetY(), srect.GetWidth(), srect.GetHeight());

--- a/lc3edit/CMakeLists.txt
+++ b/lc3edit/CMakeLists.txt
@@ -10,7 +10,6 @@ add_definitions(-DSCI_LEXER -DLINK_LEXERS -DGTK -D__WX__)
 
 set(wxWidgets_USE_LIBS xrc xml html adv gl net core base)
 find_package(wxWidgets REQUIRED)
-execute_process(COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --cxxflags)
 include(${wxWidgets_USE_FILE})
 set(CMAKE_SKIP_RPATH TRUE)
 

--- a/liblc3/lc3_plugin.cpp
+++ b/liblc3/lc3_plugin.cpp
@@ -65,7 +65,7 @@ std::vector<RLEColorEntry> InstructionPlugin::GetInstructionColoring(unsigned sh
   */
 bool lc3_install_plugin(lc3_state& state, const std::string& filename, const PluginParams& params)
 {
-    std::string realfilename = "lib" + filename + ".so";
+    std::string realfilename = "lib" + filename + SO_SUFFIX;
     void *hndl = dlopen(realfilename.c_str(), RTLD_NOW);
     // Failed to load.
     if(hndl == NULL)

--- a/plugins/other/CMakeLists.txt
+++ b/plugins/other/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(${complx-tools_SOURCE_DIR}/liblc3)
 
 set(wxWidgets_USE_LIBS stc xrc xml html adv gl net core base)
 find_package(wxWidgets REQUIRED)
-execute_process(COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --cxxflags)
 include(${wxWidgets_USE_FILE})
 set(CMAKE_SKIP_RPATH TRUE)
 


### PR DESCRIPTION
This pull request includes several changes to the CMake build system, as well as a few minor edits to the application itself, to improve the experience of compiling and using Complx on platforms besides GNU/Linux.

Changes to the application behavior:

* Adjusted the `GridCellBinaryRenderer` to work properly regardless of font size and column width. Fixes improper rendering on OS X, **ALSO fixes** improper rendering on Ubuntu/GTK when the instruction column is resized (by dragging the header).

Changes to the build system:

* Introduce a preprocessor define for the platform shared library file extension.  Fixes plugin feature not working on platforms besides Linux.
* Changes to follow several [CMake best practices](http://voices.canonical.com/jussi.pakkanen/2013/03/26/a-list-of-common-cmake-antipatterns/):
    *  use CMake's built-in Debug/Release system: `CMAKE_BUILD_TYPE`.  Eliminates the `ENABLE_DEBUG` option in preference of this method.
   * do not clobber `CXXFLAGS` that might happen to be present in the environment.
   * consistent capitalization of CMake function names
* Remove an unnecessary `link_directories` statement that otherwise generates harmless errors

Together, these changes should improve the experience of developers build Complx both on existing supported platforms, and developers attempting to port the app to other unsupported platforms.