### PR TITLE
Print full version string in complx help output

### DIFF
--- a/complx/ComplxApp.cpp
+++ b/complx/ComplxApp.cpp
@@ -166,7 +166,7 @@ bool ComplxApp::OnCmdLineParsed(wxCmdLineParser& parser)
   */
 void ComplxApp::OnInitCmdLine(wxCmdLineParser& parser)
 {
-    parser.SetLogo(wxString::Format(_("Complx Version %ld.%ld"), Version::MAJOR, Version::MINOR));
+    parser.SetLogo(wxString::Format(_("Complx Version %s"), Version::FULLVERSION_STRING));
     parser.SetDesc(cmd_descriptions);
     parser.SetSwitchChars (_("-"));
 }

--- a/complx/version.h
+++ b/complx/version.h
@@ -2,9 +2,6 @@
 #define VERSION_H
 
 namespace Version {
-	static const long MAJOR = 4;
-	static const long MINOR = 15;
-
 	static const char FULLVERSION_STRING[] = "4.15.4";
 }
 #endif


### PR DESCRIPTION
In the output for `complx -h`, print the full version number (4.15.4), not only the major and minor version (4.15).

I realize this is super trivial, Brandon, so I hope I'm not wasting your time too much here. But there was a Piazza question (`@458`) where the missing third version component confused someone, and I can't blame them completely. Well, except that they could've just opened complx and looked at the window title 😃!