### PR TITLE
Fix for Mac / Clang compilation issue

### DIFF
--- a/liblc3/lc3_test.cpp
+++ b/liblc3/lc3_test.cpp
@@ -72,7 +72,7 @@ int edit_distance(const std::vector<short>& s, const std::vector<short>& t)
 
 struct lc3_subroutine_call_info_cmp
 {
-    bool operator()(const lc3_subroutine_call_info& a, const lc3_subroutine_call_info& b)
+    bool operator() (const lc3_subroutine_call_info& a, const lc3_subroutine_call_info& b) const
     {
         if (a.address != b.address)
             return a.address < b.address;


### PR DESCRIPTION
Added missing const marker on lc3_subroutine_call_info_cmp operator method.

The Clang compiler on Mac was failing due to an error with this line where the operator method needed to be marked const but wasn’t. I have tested complx and the tests on recent homeworks after compiling with this modification and everything seems to be working just fine now.