### PR TITLE
Modernize Dockerfile

### DIFF
--- a/run_docker.sh
+++ b/run_docker.sh
@@ -7,7 +7,7 @@
 # Error out when anything goes wrong
 set -e
 
-IMAGE_NAME="jgkamat/complx"
+IMAGE_NAME="ausbin/complx"
 
 # get location of script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -26,13 +26,13 @@ if ! docker images | grep -q "$IMAGE_NAME"; then
 fi
 
 if [ -n "$1" ] && [ -d "$1" ]; then
-	echo "Linking user specified dir '$1' on your system to '/home/developer/homework' in the container"
-	LINK="-v $1:/home/developer/homework"
+	echo "Linking user specified dir '$1' on your system to '/home/developer/workdir' in the container"
+	LINK="-v $1:/home/developer/workdir"
 fi
 
 # Docker image has been built, lets run it.
-# If this fails, run `xhost +` to disable x socket security (arch)
-docker run -ti \
+# If this fails, run `xhost +` to disable x socket security
+docker run \
 	-e DISPLAY=$DISPLAY \
 	-v /tmp/.X11-unix:/tmp/.X11-unix $LINK \
 	"$IMAGE_NAME"


### PR DESCRIPTION
Bring the Dockerfile into the beautiful bright world of 2018. Make it
use Ubuntu 16.04 (the OS we require in 2110 in Spring 2018), and use
Brandon's PPA instead of compiling it locally and copying into the image
at build time.