### PR TITLE
Update relative import path of pylc3

### DIFF
--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -62,6 +62,7 @@ else(SKBUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
-    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.unittests.lc3_unit_test_case_test WORKING_DIRECTORY get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
-    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.cli.comp_test WORKING_DIRECTORY get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
+    set(PYTHON_WORKING_DIR get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
+    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${PYTHON_WORKING_DIR})
+    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.cli.comp_test WORKING_DIRECTORY ${PYTHON_WORKING_DIR})
 endif(SKBUILD)

--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -62,6 +62,6 @@ else(SKBUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
-    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m cli.comp_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m .unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m .cli.comp_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif(SKBUILD)

--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -59,11 +59,7 @@ else(SKBUILD)
 
     add_custom_command(
         TARGET pylc3 POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/unittests/pylc3.so
-        COMMENT "Copying needed plugins for testing")
-    add_custom_command(
-        TARGET pylc3 POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/cli/pylc3.so
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
     add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/unittests/lc3_unit_test_case_test.py)

--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -62,7 +62,7 @@ else(SKBUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
-    set(PYTHON_WORKING_DIR get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
+    get_filename_component(PYTHON_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
     add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${PYTHON_WORKING_DIR})
     add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.cli.comp_test WORKING_DIRECTORY ${PYTHON_WORKING_DIR})
 endif(SKBUILD)

--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -62,6 +62,6 @@ else(SKBUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
-    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/unittests/lc3_unit_test_case_test.py)
-    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cli/comp_test.py)
+    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m cli.comp_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif(SKBUILD)

--- a/pylc3/CMakeLists.txt
+++ b/pylc3/CMakeLists.txt
@@ -62,6 +62,6 @@ else(SKBUILD)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/pylc3/pylc3.so ${CMAKE_CURRENT_SOURCE_DIR}/pylc3.so
         COMMENT "Copying needed plugins for testing")
 
-    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m .unittests.lc3_unit_test_case_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m .cli.comp_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME lc3_unit_test_case_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.unittests.lc3_unit_test_case_test WORKING_DIRECTORY get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
+    add_test(NAME comp_test COMMAND ${PYTHON_EXECUTABLE} -m pylc3.cli.comp_test WORKING_DIRECTORY get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY))
 endif(SKBUILD)

--- a/pylc3/__init__.py
+++ b/pylc3/__init__.py
@@ -1,0 +1,1 @@
+# This is here so that when pylc3.so is added here, cli and unittests can import it.

--- a/pylc3/cli/comp.py
+++ b/pylc3/cli/comp.py
@@ -3,7 +3,7 @@ import cmd
 import enum
 import inspect
 import shlex
-import pylc3
+from .. import pylc3
 
 def toShort(value):
     """Converts a value into a 16 bit unsigned short.

--- a/pylc3/cli/comp_test.py
+++ b/pylc3/cli/comp_test.py
@@ -1,5 +1,5 @@
 import comp
-import pylc3
+from .. import pylc3
 import unittest
 
 

--- a/pylc3/unittests/lc3_unit_test_case.py
+++ b/pylc3/unittests/lc3_unit_test_case.py
@@ -4,7 +4,7 @@
 """
 import base64
 import enum
-import pylc3
+from .. import pylc3
 import six
 import struct
 import unittest


### PR DESCRIPTION
Right now cli and unittests expect pylc3 to be copied in the same directory as them. This should help them find it in their parent directory.